### PR TITLE
Download button to wiki link

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,13 +136,13 @@
 					<div class="slide-holder">
 						<h2 class="hidden-xs hidden-sm">Features</h2>
 						<div class="img-slide scroll-trigger"><img src="images/img-01.png" height="312" width="592" alt=""></div>
-                        <div id="press"></div>
                     </div>
 				</div>
 			</div>
 		</div>
 	</section>
     <section class="visual-container">
+        <a style="display: block; position: relative; top: -100px; visibility: hidden;" id="press"></a>
 		<div class="visual-area">
 			<div class="container">
 				<h2 style="color: #4a80f5;">Media Coverage</h2>

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 	<section class="main">
 		<div class="container">
 			<div id="cta">
-				<a href="https://github.com/AHAAAAAAA/PokemonGo-Map/archive/master.zip" class="btn btn-primary rounded">Download!</a>
+				<a href="https://github.com/AHAAAAAAA/PokemonGo-Map/wiki" class="btn btn-primary rounded">Get Started!</a>
 			</div>
 			<div class="row" id="features">
 				<div class="text-box col-md-offset-1 col-md-10">

--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
 						<table align="center" style="width:70%; font-size: 16px; line-height: 36px; font-weight: bold; color: #4a80f5;">
 							<tr><th><a href="https://github.com/AHAAAAAAA">Ahmed Almutawa(Tolo)</a> &amp; <a href="https://github.com/JZ6">JZ6</a></th></tr>
 						</table>
-						<p style="text-align:center;"><strong>Contributors</strong>: <a href="https://github.com/vintagesucks">VintageSucks</a>, Gaudon, memelyfe</p>
+						<p style="text-align:center; padding-top:20px;"><strong>Contributors</strong>: <a href="https://github.com/vintagesucks">VintageSucks</a>, <a href="https://github.com/JonahAragon">JonahAragon</a>, Gaudon, memelyfe</p>
 					</div>
                     <div class="col-md-4">
 						<h3 style="text-align:center;">Backend Devs</h3>


### PR DESCRIPTION
Changed the big download button to a link to the wiki page on how to install, so people are forced to read the instructions instead of downloading and asking for help :stuck_out_tongue_closed_eyes: 
