### PR TITLE
Download button change

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,13 +136,13 @@
 					<div class="slide-holder">
 						<h2 class="hidden-xs hidden-sm">Features</h2>
 						<div class="img-slide scroll-trigger"><img src="images/img-01.png" height="312" width="592" alt=""></div>
-                        <div id="press"></div>
                     </div>
 				</div>
 			</div>
 		</div>
 	</section>
     <section class="visual-container">
+        <a style="display: block; position: relative; top: -100px; visibility: hidden;" id="press"></a>
 		<div class="visual-area">
 			<div class="container">
 				<h2 style="color: #4a80f5;">Media Coverage</h2>

--- a/index.html
+++ b/index.html
@@ -173,11 +173,12 @@
 						<h3 style="text-align:center;">Frontend Devs</h3>
                             <table align="center" style="width:70%; font-size: 16px; line-height: 36px; font-weight: bold; color: #4a80f5; ">
                                 <tr><th style="text-align:center;">Carl</th>
+                                    <th style="text-align:center;"><a href="https://github.com/Octylpy">Octylpy</a></th></tr>
                                 <tr><th style="text-align:center;"><a href="https://github.com/foodforarabbit">Rabbitz</a></th>
                                     <th style="text-align:center;"><a href="https://github.com/solojungle">Ali Awari</a></th></tr>
                                 <tr><th style="text-align:center;"><a href="http://frostthefox.pw/">Thunderfox</a></th>
                                     <th style="text-align:center;"><a href="https://github.com/Vixus-">Vixus</a></th></tr>
-                                <tr><th style="text-align:center;"><a href="https://github.com/Octylpy">Octylpy</a></th></tr>
+                                <tr></tr>
                             </table>
 					</div>
 					<div class="col-md-4">
@@ -218,19 +219,19 @@
 					<div class="col-md-4 col-mid">
 						<h3>Contact Us</h3>
                         <p>Contact developers and find other members of our community.</p>
-                        <p><font color="#4a80f5">Bitcoin donations appreciated! 18ABe5rhZgLR6zdH27hDWp8DdTkWKJoKwo</font></p>
+                        <p>Bitcoin donations appreciated! <b>18ABe5rhZgLR6zdH27hDWp8DdTkWKJoKwo</b></p>
 						<p><a href="https://github.com/AHAAAAAAA/PokemonGo-Map">GitHub</a> / <a href="https://discord.gg/TPNKxuX">Discord</a> / <a href="https://www.reddit.com/r/pokemongodev">Reddit</a></p>
 					</div>
 					<div class="col-md-4 col-right">
 						<div class="text-frame">
 							<h3>Info</h3>
 							<p>This site is not associated with The Pokémon Company or Niantic. All rights belong to their respective owners.</p>
-							<p><form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+							<form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
 <input type="hidden" name="cmd" value="_s-xclick">
 <input type="hidden" name="encrypted" value="-----BEGIN PKCS7-----MIIHLwYJKoZIhvcNAQcEoIIHIDCCBxwCAQExggEwMIIBLAIBADCBlDCBjjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtQYXlQYWwgSW5jLjETMBEGA1UECxQKbGl2ZV9jZXJ0czERMA8GA1UEAxQIbGl2ZV9hcGkxHDAaBgkqhkiG9w0BCQEWDXJlQHBheXBhbC5jb20CAQAwDQYJKoZIhvcNAQEBBQAEgYCi5aaSl4QRynRfJuS6HcebiZUxOKeh99o2PDy8WVHpI5pQhS7psOJYLUrRPn4E38Hs8zQXW4JE6wYZ7rmpOtpb10oBqgcEKzwyipFz4Qhoz6ZBhbLGTrdr11O9tchFveTCvuZSp3SwJAdCDjWwE4qFCP9DL3RP5vrfuAGW5WokzDELMAkGBSsOAwIaBQAwgawGCSqGSIb3DQEHATAUBggqhkiG9w0DBwQIxhfqGjlnnoKAgYisOHZxyF/uk9cOSyl5bHqYrtusTzQAMgw3uSfq7QQvH+DhLszW5o2ej2c9/8ZyitnFIN0At4Dahz5aBMlS6cHKi00K5anXeBmArHutY6uU4/RqKe9CcJVj6N69NTseJLv7ktivzcCLuivdDo8DTt68pqdDQCJPM2L88ZIpB0qroPhiG3Qh/3LboIIDhzCCA4MwggLsoAMCAQICAQAwDQYJKoZIhvcNAQEFBQAwgY4xCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLUGF5UGFsIEluYy4xEzARBgNVBAsUCmxpdmVfY2VydHMxETAPBgNVBAMUCGxpdmVfYXBpMRwwGgYJKoZIhvcNAQkBFg1yZUBwYXlwYWwuY29tMB4XDTA0MDIxMzEwMTMxNVoXDTM1MDIxMzEwMTMxNVowgY4xCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLUGF5UGFsIEluYy4xEzARBgNVBAsUCmxpdmVfY2VydHMxETAPBgNVBAMUCGxpdmVfYXBpMRwwGgYJKoZIhvcNAQkBFg1yZUBwYXlwYWwuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDBR07d/ETMS1ycjtkpkvjXZe9k+6CieLuLsPumsJ7QC1odNz3sJiCbs2wC0nLE0uLGaEtXynIgRqIddYCHx88pb5HTXv4SZeuv0Rqq4+axW9PLAAATU8w04qqjaSXgbGLP3NmohqM6bV9kZZwZLR/klDaQGo1u9uDb9lr4Yn+rBQIDAQABo4HuMIHrMB0GA1UdDgQWBBSWn3y7xm8XvVk/UtcKG+wQ1mSUazCBuwYDVR0jBIGzMIGwgBSWn3y7xm8XvVk/UtcKG+wQ1mSUa6GBlKSBkTCBjjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtQYXlQYWwgSW5jLjETMBEGA1UECxQKbGl2ZV9jZXJ0czERMA8GA1UEAxQIbGl2ZV9hcGkxHDAaBgkqhkiG9w0BCQEWDXJlQHBheXBhbC5jb22CAQAwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOBgQCBXzpWmoBa5e9fo6ujionW1hUhPkOBakTr3YCDjbYfvJEiv/2P+IobhOGJr85+XHhN0v4gUkEDI8r2/rNk1m0GA8HKddvTjyGw/XqXa+LSTlDYkqI8OwR8GEYj4efEtcRpRYBxV8KxAW93YDWzFGvruKnnLbDAF6VR5w/cCMn5hzGCAZowggGWAgEBMIGUMIGOMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDU1vdW50YWluIFZpZXcxFDASBgNVBAoTC1BheVBhbCBJbmMuMRMwEQYDVQQLFApsaXZlX2NlcnRzMREwDwYDVQQDFAhsaXZlX2FwaTEcMBoGCSqGSIb3DQEJARYNcmVAcGF5cGFsLmNvbQIBADAJBgUrDgMCGgUAoF0wGAYJKoZIhvcNAQkDMQsGCSqGSIb3DQEHATAcBgkqhkiG9w0BCQUxDxcNMTYwNzIyMjAwMjEzWjAjBgkqhkiG9w0BCQQxFgQU8VppKmG95P7QqbXmbl1nydLm2H8wDQYJKoZIhvcNAQEBBQAEgYBB3D7wZNUFlRs19F7coPA+5o93LI9idrtVpHYso/XG51dM6jtQH5u9DqTXzuPQnz8G9IOpSEkbgeRRTRME+NF89w+ibGnStv5RZ7mCRkGBXKLtOObwzWtFq5zYtd/emy3mU6Zm7TmahxfRECp5891vZba/QSu1+aEsqDLZRG7xDA==-----END PKCS7-----
 ">
 <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-<img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1"></p>
+<img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
 </form>
 
 						</div>

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 	<section class="main">
 		<div class="container">
 			<div id="cta">
-				<a href="https://github.com/AHAAAAAAA/PokemonGo-Map/archive/master.zip" class="btn btn-primary rounded">Download!</a>
+				<a href="https://github.com/AHAAAAAAA/PokemonGo-Map/releases" class="btn btn-primary rounded">Get Started!</a>
 			</div>
 			<div class="row" id="features">
 				<div class="text-box col-md-offset-1 col-md-10">


### PR DESCRIPTION
Commit 473040e - Now points to [release page](https://github.com/AHAAAAAAA/PokemonGo-Map/releases) instead of direct download so people can see versioning/changelogs.
